### PR TITLE
[fix][17] - Text Owner and address are not align with each other

### DIFF
--- a/src/app/pages/token-cosmos/token-content/token-content-tab/token-inventory-tab/token-inventory-tab.component.html
+++ b/src/app/pages/token-cosmos/token-content/token-content-tab/token-inventory-tab/token-inventory-tab.component.html
@@ -53,7 +53,7 @@
                 </a>
                 <app-name-tag
                   *ngIf="!breakpoint.value.matches"
-                  class="small-text text--primary hover-link mt-1"
+                  class="small-text text--primary hover-link"
                   [value]="item.owner"
                   [linkRouter]="['/token', 'cw721', item.contract_address]"
                   [linkParams]="{ a: item.owner }">


### PR DESCRIPTION
- CW721: Token tracker page_Inventory page